### PR TITLE
Added SpoilerAL SSGs

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -55,6 +55,8 @@
                 <tr>
                     <td><a href='https://mega.nz/#!OpxFSSJB!2eUH91vJAF_ejq7S5r3x5Jx7GYCP67LSSo4BuXhoDa4'>SSGs (niL, Japanese)</a></td>
                 </tr>
+		<tr>
+		    <td><a href='https://drive.google.com/open?id=1P8ChNXiK_WR4ZgR-UqHCmwFO6h951Iyf'>SSGs (niL, English translated)</a></td>
                 <tr>
                     <td><a href='https://mega.nz/#!QUBTEB5J!idRbiOfr_BKFpMBy9e5qU5Ow1xPkxplVbR72G6Ud0KI'>MoF SSG by Akaldar</a></td>
                 </tr>
@@ -64,6 +66,15 @@
                 <tr>
                     <td><a href='http://www7b.biglobe.ne.jp/~chibimi/th16-toggle.zip'>HSiFS SSG</a></td>
                 </tr>
+		<tr>
+		    <td><a href='https://drive.google.com/open?id=1YqL8QSrnvDepMnkKUNPIBJVaJ2XWwZhP'>HSiFS SSG (English translated)</a></td>
+		</tr>
+		<tr>
+                    <td><a href=''>Alternative HSiFS SSG (May multiply and cause other SSGs in the menu to become invisible)</a></td>
+		</tr>
+		<tr>
+			<td><a href='https://drive.google.com/open?id=1R8YcGWBE1c4jLy2RGfjuqtrpZzR26XA-'>Alternative HSiFS SSG (May multiply and cause other SSGs in the menu to become invisible) (English translated) </a></td>
+		</tr>
             </table>
             <!-- General Practice Tools -->
             <hr>

--- a/tools.html
+++ b/tools.html
@@ -63,6 +63,9 @@
                 <tr>
                     <td><a href='https://ux.getuploader.com/leo_1729/download/23'>TD Scoring SSG by Leo</a></td>
                 </tr>
+		<tr>
+		    <td><a href='https://drive.google.com/open?id=1Qs4jOBkDH3dN7tI5X2cJRzd_awZFf80d'>TD Scoring SSG by Leo (English translated)</a></td>
+		</tr>
                 <tr>
                     <td><a href='http://www7b.biglobe.ne.jp/~chibimi/th16-toggle.zip'>HSiFS SSG</a></td>
                 </tr>

--- a/tools.html
+++ b/tools.html
@@ -70,9 +70,6 @@
 		    <td><a href='https://drive.google.com/open?id=1YqL8QSrnvDepMnkKUNPIBJVaJ2XWwZhP'>HSiFS SSG (English translated)</a></td>
 		</tr>
 		<tr>
-                    <td><a href=''>Alternative HSiFS SSG (May multiply and cause other SSGs in the menu to become invisible)</a></td>
-		</tr>
-		<tr>
 			<td><a href='https://drive.google.com/open?id=1R8YcGWBE1c4jLy2RGfjuqtrpZzR26XA-'>Alternative HSiFS SSG (May multiply and cause other SSGs in the menu to become invisible) (English translated) </a></td>
 		</tr>
             </table>


### PR DESCRIPTION
Hey Maribel,
I just wanted to let you know that I feel that the SpoilerAL SSGs provided on maribelhearn.github.io/tools#spoileral are a bit lacking in my opinion. I have added the English niL SSGs, a translation for `th16-toggle.ssg` and a translated alternative SSG for HSiFS. If you still have the Japanese version, please add it to the page as well as I no longer have the original Japanese SSG anymore.