### PR TITLE
Fixed tools.html.

### DIFF
--- a/tools.html
+++ b/tools.html
@@ -56,7 +56,7 @@
                     <td><a href='https://mega.nz/#!OpxFSSJB!2eUH91vJAF_ejq7S5r3x5Jx7GYCP67LSSo4BuXhoDa4'>SSGs (niL, Japanese)</a></td>
                 </tr>
                 <tr>
-                    <td><a href='https://drive.google.com/open?id=1P8ChNXiK_WR4ZgR-UqHCmwFO6h951Iyf'>SSGs (niL, English translated)</a></td>
+                    <td><a href='http://www.mediafire.com/file/a4g4awdp4ll5a4n/SSG.zip'>SSGs (niL, English translated)</a></td>
                 </tr>
                 <tr>
                     <td><a href='https://mega.nz/#!QUBTEB5J!idRbiOfr_BKFpMBy9e5qU5Ow1xPkxplVbR72G6Ud0KI'>MoF SSG by Akaldar</a></td>


### PR DESCRIPTION
The link to the English niL SSGs now leads to niL SSGs and not to 4.6 SSGs.