### PR TITLE
Changed title fonts to Google fonts

### DIFF
--- a/404.css
+++ b/404.css
@@ -6,7 +6,7 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px times new roman;
+    font-family: 'Libre Baskerville';
 }
 #wrap {
     border: 1px solid black;

--- a/404.html
+++ b/404.html
@@ -6,6 +6,7 @@
 		<meta charset='UTF-8'>
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='404.css'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
 		<link rel='icon' type='image/x-icon' href='favicon.ico'>
     </head>
     

--- a/c67.html
+++ b/c67.html
@@ -7,6 +7,7 @@
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='c67/c67.css'>
 		<link rel='icon' type='image/x-icon' href='c67/c67.ico'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
         <script src='sorttable.js'></script>
     </head>
     

--- a/c67/c67.css
+++ b/c67/c67.css
@@ -5,13 +5,16 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px monotype corsiva;
+	font-family: 'Felipa';
+	font-size: 48px
 }
 h2 {
-    font: 36px monotype corsiva;
+	font-family: 'Felipa';
+	font-size: 36px
 }
 h3 {
-    font: 24px monotype corsiva;
+    font-family: 'Felipa';
+	font-size: 24px
 }
 p {
     font: 14px verdana, sans-serif;

--- a/drc.html
+++ b/drc.html
@@ -7,6 +7,7 @@
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='drc/drc.css'>
 		<link rel='icon' type='x/icon' href='drc/power.ico'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
         <script src='sorttable.js'></script>
 		<script src='jquery.js'></script>
 		<script src='utils.js'></script>

--- a/drc/drc.css
+++ b/drc/drc.css
@@ -8,10 +8,12 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px monotype corsiva;
+	    font-family: 'Felipa';
+		font-size: 48px
 }
 h2 {
-    font: 36px monotype corsiva;
+		font-family: 'Felipa';
+		font-size: 36px
 }
 .center {
     margin-left: auto;

--- a/history.html
+++ b/history.html
@@ -7,6 +7,7 @@
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='history/history.css'>
 		<link rel='icon' type='image/x-icon' href='favicon.ico'>
+        <link href="https://fonts.googleapis.com/css?family=Libre+Baskerville" rel="stylesheet">
 		<script src='jquery.js'></script>
 		<script src='utils.js'></script>
 		<script src='history/calendar.js'></script>

--- a/history/history.css
+++ b/history/history.css
@@ -1,6 +1,6 @@
 body {
 	background: url('eosdbig.jpg') top no-repeat fixed;
-    font-family: 'Libre Baskerville';
+  	font-family: 'Libre Baskerville';
 }
 table, tr, th, td {
 	border: 3px solid hotpink;

--- a/history/history.css
+++ b/history/history.css
@@ -1,6 +1,6 @@
 body {
 	background: url('eosdbig.jpg') top no-repeat fixed;
-    font: 16px times new roman;
+    font-family: 'Libre Baskerville';
 }
 table, tr, th, td {
 	border: 3px solid hotpink;

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
 		<meta charset='UTF-8'>
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='main.css'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
 		<link rel='icon' type='image/x-icon' href='favicon.ico'>
         <link rel='dns-prefetch' href='history'>
         <link rel='dns-prefetch' href='scoring'>

--- a/jargon.html
+++ b/jargon.html
@@ -7,6 +7,7 @@
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='jargon/jargon.css'>
 		<link rel='icon' type='image/x-icon' href='jargon/bomb.ico'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
 	</head>
 	
 	<body>

--- a/jargon/jargon.css
+++ b/jargon/jargon.css
@@ -5,10 +5,12 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px 'monotype corsiva';
+	    font-family: 'Felipa';
+		font-size: 48px
 }
 h2 {
-    font: 36px 'monotype corsiva';
+		font-family: 'Felipa';
+		font-size: 36px
 }
 #wrap {
     border: 1px solid black;

--- a/lnn.html
+++ b/lnn.html
@@ -7,6 +7,7 @@
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='lnn/lnn.css'>
 		<link rel='icon' type='image/x-icon' href='lnn/full.ico'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
 		<script src='sorttable.js'></script>
 		<script src='jquery.js'></script>
 		<script src='utils.js'></script>

--- a/lnn/lnn.css
+++ b/lnn/lnn.css
@@ -5,10 +5,12 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px monotype corsiva;
+	    font-family: 'Felipa';
+		font-size: 48px
 }
 h2 {
-    font: 36px monotype corsiva;
+		font-family: 'Felipa';
+		font-size: 36px
 }
 table {
     margin-left: auto;

--- a/main.css
+++ b/main.css
@@ -6,12 +6,12 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-	    font-family: 'Felipa';
-		font-size: 48px
+	font-family: 'Felipa';
+	font-size: 48px
 }
 h2 {
-		font-family: 'Felipa';
-		font-size: 36px
+	font-family: 'Felipa';
+	font-size: 36px
 }
 p {
     margin: 10px;

--- a/main.css
+++ b/main.css
@@ -6,10 +6,12 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px monotype corsiva;
+	    font-family: 'Felipa';
+		font-size: 48px
 }
 h2 {
-    font: 36px monotype corsiva;
+		font-family: 'Felipa';
+		font-size: 36px
 }
 p {
     margin: 10px;

--- a/scoring.html
+++ b/scoring.html
@@ -7,6 +7,7 @@
 		<meta name='viewport' content='width=device-width'>
 		<link id='css' rel='stylesheet' type='text/css' href='scoring/scoring.css'>
 		<link rel='icon' type='image/x-icon' href='scoring/spell.ico'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
         <script src='sorttable.js'></script>
         <script src='jquery.js'></script>
 		<script src='utils.js'></script>

--- a/scoring/scoring.css
+++ b/scoring/scoring.css
@@ -5,10 +5,12 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px monotype corsiva;
+	    font-family: 'Felipa';
+		font-size: 48px
 }
 h2 {
-    font: 36px monotype corsiva;
+		font-family: 'Felipa';
+		font-size: 36px
 }
 input[type=text] {
     width: 85px;

--- a/survival.html
+++ b/survival.html
@@ -7,6 +7,7 @@
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='survival/survival.css'>
 		<link rel='icon' type='image/x-icon' href='survival/survival.ico'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
         <script src='sorttable.js'></script>
 		<script src='jquery.js'></script>
 		<script src='utils.js'></script>

--- a/survival/survival.css
+++ b/survival/survival.css
@@ -8,10 +8,12 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px monotype corsiva;
+	    font-family: 'Felipa';
+		font-size: 48px
 }
 h2 {
-    font: 36px monotype corsiva;
+		font-family: 'Felipa';
+		font-size: 36px
 }
 #wrap {
     border: 1px solid black;

--- a/thvote.html
+++ b/thvote.html
@@ -7,6 +7,7 @@
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='thvote/thvote.css'>
 		<link rel='icon' type='image/x-icon' href='thvote/tou-32.ico'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
         <script src='sorttable.js'></script>
         <script src='jquery.js'></script>
         <script src='thvote/thvote.js'></script>

--- a/thvote/thvote.css
+++ b/thvote/thvote.css
@@ -5,13 +5,16 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px monotype corsiva;
+	    font-family: 'Felipa';
+		font-size: 48px
 }
 h2 {
-    font: 36px monotype corsiva;
+		font-family: 'Felipa';
+		font-size: 36px
 }
 h3 {
-    font: 24px monotype corsiva;
+		font-family: 'Felipa';
+		font-size: 24px
 }
 table {
     margin-left: auto;

--- a/tools.html
+++ b/tools.html
@@ -5,7 +5,18 @@
 		<title>Touhou Patches and Tools</title>
 		<meta charset='UTF-8'>
 		<meta name='viewport' content='width=device-width'>
+		<link href='https://fonts.googleapis.com/css?family=Felipa' rel='stylesheet'>
 		<link rel='stylesheet' type='text/css' href='tools/tools.css'>
+		<style>
+			h1 {
+				font-family: 'Felipa';
+				font-size: 48px
+			}
+			h2 {
+				font-family: 'Felipa';
+				font-size: 36px
+			}
+		</style>
 		<link rel='icon' type='image/x-icon' href='tools/ufo.ico'>
 	</head>
 	

--- a/tools.html
+++ b/tools.html
@@ -7,16 +7,6 @@
 		<meta name='viewport' content='width=device-width'>
 		<link href='https://fonts.googleapis.com/css?family=Felipa' rel='stylesheet'>
 		<link rel='stylesheet' type='text/css' href='tools/tools.css'>
-		<style>
-			h1 {
-				font-family: 'Felipa';
-				font-size: 48px
-			}
-			h2 {
-				font-family: 'Felipa';
-				font-size: 36px
-			}
-		</style>
 		<link rel='icon' type='image/x-icon' href='tools/ufo.ico'>
 	</head>
 	

--- a/tools/tools.css
+++ b/tools/tools.css
@@ -4,15 +4,14 @@ body {
 div {
     background-color: #FFFFFF;
 }
-/*
 h1 {
-    font-family:'Elise', 'cursive';
+	    font-family: 'Felipa';
+		font-size: 48px
 }
-
 h2 {
-    font: 36px 'monotype corsiva';
+		font-family: 'Felipa';
+		font-size: 36px
 }
-*/
 table {
     margin-left: auto;
     margin-right: auto;

--- a/tools/tools.css
+++ b/tools/tools.css
@@ -4,12 +4,15 @@ body {
 div {
     background-color: #FFFFFF;
 }
+/*
 h1 {
-    font: 48px 'monotype corsiva';
+    font-family:'Elise', 'cursive';
 }
+
 h2 {
     font: 36px 'monotype corsiva';
 }
+*/
 table {
     margin-left: auto;
     margin-right: auto;

--- a/wr.html
+++ b/wr.html
@@ -7,6 +7,7 @@
 		<meta name='viewport' content='width=device-width'>
 		<link rel='stylesheet' type='text/css' href='wr/wr.css'>
 		<link rel='icon' type='image/x-icon' href='wr/point.ico'>
+        <link href="https://fonts.googleapis.com/css?family=Felipa" rel="stylesheet">
 		<script src='sorttable.js'></script>
 		<script src='jquery.js'></script>
 		<script src='utils.js'></script>

--- a/wr/wr.css
+++ b/wr/wr.css
@@ -5,10 +5,12 @@ div {
     background-color: #FFFFFF;
 }
 h1 {
-    font: 48px monotype corsiva;
+	    font-family: 'Felipa';
+		font-size: 48px
 }
 h2 {
-    font: 36px monotype corsiva;
+		font-family: 'Felipa';
+		font-size: 36px
 }
 table {
     margin-left: auto;


### PR DESCRIPTION
The title fonts now all use Google Fonts as a web font framework to have unified fonts across all platforms and not just the one which have Monotype Corsiva (aka just Windows) while all other platforms use a fallback font. I have also changed every font specification for Times New Roman to Libre Baskerville because it's a free font and I also use Google Fonts for that font as well.